### PR TITLE
refactor: add new error to throw

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ GitHub action to publish a pre-release version of an npm package to the registry
 
 ### github_token
 
-A token that GitHub automatically creates and stores in a GITHUB_TOKEN secret to use in your workflow.
+A token that GitHub automatically creates and stores in a `GITHUB_TOKEN` secret to use in your workflow.
 
 ### npm_token
 

--- a/index.mjs
+++ b/index.mjs
@@ -60,6 +60,7 @@ const postCommentToPullRequest = async (client, commentBody) => {
 try {
   const githubToken = core.getInput('github_token');
   const npmToken = core.getInput('npm_token');
+  const commitHash = context.payload.after;
 
   if (!githubToken) {
     throw new Error('No GitHub token provided');
@@ -69,9 +70,12 @@ try {
     throw new Error('No npm token provided');
   }
 
+  if (!commitHash) {
+    throw new Error('Current commit could not be determined');
+  }
+
   const isDryRun = coerceToBoolean(core.getInput('dry_run'));
   const githubClient = getGithubClient(githubToken);
-  const commitHash = context.payload.after;
   const { name, currentVersion } = loadPackageJson();
   const uniqueVersion = getUniqueVersion(currentVersion, commitHash);
   const commentBody = generatePullRequestComment(


### PR DESCRIPTION
also throw an error with the most recent git hash cannot be determined since that is necessary to create a unique version