### PR TITLE
refactor: npm script name change

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -62,6 +62,7 @@ try {
   const npmToken = core.getInput('npm_token');
   const commitHash = context.payload.after;
 
+  // early exit because we cannot proceed without these variables
   if (!githubToken) {
     throw new Error('No GitHub token provided');
   }

--- a/package.json
+++ b/package.json
@@ -4,8 +4,9 @@
   "description": "GitHub action created to publish a branch of an npm package repo to npm registry",
   "main": "dist/index.mjs",
   "scripts": {
+    "build": "ncc build index.mjs -o dist --source-map --license licenses.txt",
     "lint": "eslint --cache --ext mjs .",
-    "prepare": "ncc build index.mjs -o dist --source-map --license licenses.txt",
+    "preversion": "npm run build && git add -A dist",
     "test": "ava"
   },
   "dependencies": {


### PR DESCRIPTION
rename "prepare" npm script to "build" and run it on "preversion" lifecycle hook; this means that when `npm version` commands are run a new version will be built and committed alongside the tag and `package.json` version change