### PR TITLE
refactor: log error in catch block

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -96,5 +96,6 @@ try {
   // post comment to PR
   await postCommentToPullRequest(githubClient, commentBody);
 } catch (error) {
+  console.log(error); // eslint-disable-line
   core.setFailed(error.message);
 }


### PR DESCRIPTION
in addition to setting setFailed with the error object message, also log it so the action output shows more details about the error, including a stack trace