### PR TITLE
refactor: add commit input

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,7 @@ An npm access token. See [https://docs.npmjs.com/creating-and-viewing-access-tok
 ### dry_run
 
 As of `npm@6`, does everything publish would do except actually publishing to the registry. Reports the details of what would have been published, see [npm publish docs](https://docs.npmjs.com/cli/v7/commands/npm-publish).
+
+### commit
+
+The SHA-1 hash of the last commit; this is set automatically and does not need to be provided, but it can be overridden.

--- a/action.yml
+++ b/action.yml
@@ -12,6 +12,10 @@ inputs:
     description: 'if true, will run without actually publishing to npm'
     required: false
     default: false
+  commit:
+    description: 'SHA-1 hash of the last commit'
+    required: false
+    default: '${{ github.event.pull_request.head.sha }}'
 
 runs:
   using: 'node16'

--- a/index.mjs
+++ b/index.mjs
@@ -20,7 +20,7 @@ try {
   // action inputs
   const githubToken = core.getInput('github_token');
   const npmToken = core.getInput('npm_token');
-  const commitHash = context.payload.after;
+  const commitHash = core.getInput('commit');
   const isDryRun = core.getInput('dry_run');
 
   // early exit because we cannot proceed without these variables

--- a/index.mjs
+++ b/index.mjs
@@ -4,63 +4,24 @@ import { context } from '@actions/github';
 
 import {
   coerceToBoolean,
-  getUniqueVersion,
   generatePullRequestComment,
   getCommentIdentifier,
-  getCommentId,
   getGithubClient,
   getNpmAuthCommand,
-  getUpdatePackageVersionCommand,
   getPackageNameAndVersion,
-  loadPackageJson,
   getPublishPackageCommand,
+  getUniqueVersion,
+  getUpdatePackageVersionCommand,
+  loadPackageJson,
+  postCommentToPullRequest,
 } from './helpers.mjs';
 
-// returns an array of comments from current PR
-const getCommentList = async (client, issue) => {
-  const options = {
-    owner: issue.owner,
-    repo: issue.repo,
-    issue_number: issue.number,
-  };
-
-  return client.rest.issues.listComments(options);
-};
-
-// posts a comment to the PR if none have been posted yet, but any new posts
-// (for example, when a new commit is pushed to the PR) will update original comment
-// so that there is only ever a single comment being made by this action
-const postCommentToPullRequest = async (client, commentBody) => {
-  if (!context.issue.number) {
-    throw new Error('This is not a PR or commenting is disabled');
-  }
-
-  const { data: commentList } = await getCommentList(client, context.issue);
-  const commentId = getCommentId(commentList, getCommentIdentifier());
-
-  if (commentId) {
-    await client.rest.issues.updateComment({
-      issue_number: context.issue.number,
-      owner: context.issue.owner,
-      repo: context.issue.repo,
-      body: commentBody,
-      comment_id: commentId,
-    });
-    return;
-  }
-
-  await client.rest.issues.createComment({
-    issue_number: context.issue.number,
-    owner: context.repo.owner,
-    repo: context.repo.repo,
-    body: commentBody,
-  });
-};
-
 try {
+  // action inputs
   const githubToken = core.getInput('github_token');
   const npmToken = core.getInput('npm_token');
   const commitHash = context.payload.after;
+  const isDryRun = core.getInput('dry_run');
 
   // early exit because we cannot proceed without these variables
   if (!githubToken) {
@@ -72,10 +33,9 @@ try {
   }
 
   if (!commitHash) {
-    throw new Error('Current commit could not be determined');
+    throw new Error('Current commit hash could not be determined');
   }
 
-  const isDryRun = coerceToBoolean(core.getInput('dry_run'));
   const githubClient = getGithubClient(githubToken);
   const { name, currentVersion } = loadPackageJson();
   const uniqueVersion = getUniqueVersion(currentVersion, commitHash);
@@ -91,10 +51,10 @@ try {
   execSync(getUpdatePackageVersionCommand(uniqueVersion));
 
   // publish package
-  execSync(getPublishPackageCommand(isDryRun));
+  execSync(getPublishPackageCommand(coerceToBoolean(isDryRun)));
 
   // post comment to PR
-  await postCommentToPullRequest(githubClient, commentBody);
+  await postCommentToPullRequest(context, githubClient, commentBody);
 } catch (error) {
   console.log(error); // eslint-disable-line
   core.setFailed(error.message);


### PR DESCRIPTION
`context.payload.after` only worked after subsequent pushes to a PR (ie. the initial opening of the PR caused a failure because `commitHash` would be undefined). I couldn't find a reliable source of the hash in `context` so instead we pass it in via `github.event.pull_request.head.sha`. 

note that `github.sha` doesn't work for reasons explained here: https://stackoverflow.com/a/68068674 

