### PR TITLE
fix: add package name to comment identifier

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -14,7 +14,7 @@ inputs:
     required: true
     default: '${{ github.event.pull_request.head.sha }}'
   workspace:
-    description: 'Can be used to specify a workspace to publish'
+    description: 'Can be used to specify a workspace to publish (assumes package lives in ./packages/*)'
     required: false
     default: ''
   dry_run:

--- a/helpers.mjs
+++ b/helpers.mjs
@@ -157,6 +157,7 @@ export const generateInstallationInstructionsMarkdown = (
   packageNameAndVersion,
   commentIdentifier,
 ) => {
+  // TODO: use Intl.DateTimeFormat to format date and time for different locales
   const currentDate = new Date();
 
   return `${commentIdentifier}
@@ -206,7 +207,8 @@ export const postCommentToPullRequest = async (packageName, packageNameAndVersio
   }
 
   // string used to identify a comment in a PR made by this action
-  const commentIdentifier = '<!-- NPM_PUBLISH_BRANCH_COMMENT_PR -->';
+  // TODO: in a workspace setting it could be nice to combine the packages into a single comment
+  const commentIdentifier = `<!-- NPM_PUBLISH_BRANCH_COMMENT_PR_${packageName.toUppercase()} -->`;
   const { githubToken } = getInputs();
   const githubClient = getGithubClient(githubToken);
   const commentBody = generateInstallationInstructionsMarkdown(


### PR DESCRIPTION
previously it was assumed there was only a single one of these comments in a PR so `NPM_PUBLISH_BRANCH_COMMENT_PR` was a sufficient identifier but in a workspace situation there could be multiple packages being published so we should use `NPM_PUBLISH_BRANCH_COMMENT_PR_@NAMESPACE/PACKAGE-NAME` as an identifier.